### PR TITLE
Add Discord alerts on main branch updates

### DIFF
--- a/.github/workflows/alert.yaml
+++ b/.github/workflows/alert.yaml
@@ -1,0 +1,21 @@
+name: Notify on Main Merge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord Notification
+        uses: Ilshidur/action-discord@master
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          message: |
+            🚀 A new commit was pushed to **main** branch!
+            Repository: ${{ github.repository }}
+            Commit: ${{ github.sha }}
+            Author: ${{ github.actor }}
+            Message: ${{ github.event.head_commit.message }}


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to send notifications to a Discord channel whenever a new commit is pushed to the main branch.

- Created a new workflow file `.github/workflows/alert.yml`
- Configured the workflow to trigger on push events to `main`
- Integrated the Discord webhook securely through GitHub Secrets

This setup improves visibility of repository updates directly within the team's Discord channel.
