### PR TITLE
Add unit tests for security check script

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: CI - Code Quality, Security & Checks
+    name: CI - Code Quality, Security, Unit Tests & Checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -19,11 +19,15 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install flake8
+          pip install flake8 pytest
 
       - name: Lint with flake8
         run: |
           flake8 check_security.py --max-line-length=100
+
+      - name: Run unit tests with pytest
+        run: |
+          pytest --maxfail=1 --disable-warnings -q
 
       - name: Run security check script
         run: python check_security.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 flake8
+pytest

--- a/test_check_security.py
+++ b/test_check_security.py
@@ -1,0 +1,41 @@
+import os
+import pytest
+from check_security import check_files
+
+def test_all_files_present(tmp_path, monkeypatch):
+    for filename in ["LICENSE", "README.md", "requirements.txt"]:
+        (tmp_path / filename).write_text("content")
+
+    monkeypatch.chdir(tmp_path)
+
+    check_files()
+
+def test_missing_license(tmp_path, monkeypatch):
+    (tmp_path / "README.md").write_text("content")
+    (tmp_path / "requirements.txt").write_text("content")
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit):
+        check_files()
+
+def test_missing_readme(tmp_path, monkeypatch):
+    (tmp_path / "LICENSE").write_text("content")
+    (tmp_path / "requirements.txt").write_text("content")
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit):
+        check_files()
+
+def test_missing_requirements(tmp_path, monkeypatch):
+    (tmp_path / "LICENSE").write_text("content")
+    (tmp_path / "README.md").write_text("content")
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit):
+        check_files()
+
+def test_no_files(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit):
+        check_files()


### PR DESCRIPTION
This pull request adds unit tests for the `check_security.py` script using pytest.

- 5 unit tests created
- Tests cover scenarios with missing required files
- CI workflow updated to run tests automatically on PRs

This is part of the final DevOps course assignment.
